### PR TITLE
Use repo-root variables in scripts

### DIFF
--- a/convert_to_kindle.sh
+++ b/convert_to_kindle.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
+set -e
 
-SPLIT_DIR="/home/cinder/Documents/C_Scripts/Markdown Merger/Split"
-KINDLE_DIR="/home/cinder/Documents/C_Scripts/Markdown Merger/Kindle"
+# Determine repository root from this script's location, allow override
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+# Directories for input markdown chunks and Kindle output
+SPLIT_DIR="${SPLIT_DIR:-"$REPO_ROOT/Split"}"
+KINDLE_DIR="${KINDLE_DIR:-"$REPO_ROOT/Kindle"}"
 
 mkdir -p "$KINDLE_DIR"
 

--- a/shuffle_split_files.sh
+++ b/shuffle_split_files.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
+set -e
 
-SPLIT_DIR="/home/cinder/Documents/C_Scripts/Markdown Merger/Split"
+# Determine repository root from this script's location, allow override
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+# Directory containing split markdown files
+SPLIT_DIR="${SPLIT_DIR:-"$REPO_ROOT/Split"}"
 
 # Collect all part files
 files=("$SPLIT_DIR"/part_*.md)
@@ -14,7 +19,7 @@ if [ "$count" -eq 0 ]; then
 fi
 
 # Create an array of shuffled indices from 1 to count
-shuffled_indices=($(shuf -i 1-$count))
+mapfile -t shuffled_indices < <(shuf -i 1-"$count")
 
 # Temporary rename files to avoid overwrites
 for i in "${!files[@]}"; do

--- a/split_markdown.sh
+++ b/split_markdown.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+set -e
 
-# Fixed input file path
-INPUT_FILE="/home/cinder/Documents/C_Scripts/Markdown Merger/Merged/merged_output.md"
+# Determine repository root based on this script's location, allow override
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+# Target markdown file (argument or environment variable)
+INPUT_FILE="${1:-${INPUT_FILE:-"$REPO_ROOT/Merged/merged_output.md"}}"
 
 # Output directory for split files
-OUTPUT_DIR="/home/cinder/Documents/C_Scripts/Markdown Merger/Split"
+OUTPUT_DIR="${SPLIT_DIR:-"$REPO_ROOT/Split"}"
 
 # Max characters per split file
-MAX_CHARS=20000
+MAX_CHARS="${MAX_CHARS:-20000}"
 
 if [ ! -f "$INPUT_FILE" ]; then
   echo "File not found: $INPUT_FILE"
@@ -21,7 +25,7 @@ current_chunk=""
 
 while IFS= read -r line || [ -n "$line" ]; do
   current_chunk+="$line"$'\n'
-  if [ ${#current_chunk} -ge $MAX_CHARS ]; then
+  if [ ${#current_chunk} -ge "$MAX_CHARS" ]; then
     printf -v filename "%s/part_%03d.md" "$OUTPUT_DIR" "$split_index"
     echo "$current_chunk" > "$filename"
     echo "Created $filename"


### PR DESCRIPTION
## Summary
- rename `split_output.sh` -> `split_markdown.sh`
- rename `shuffle.sh` -> `shuffle_split_files.sh`
- add repo-root path variables and optional env overrides in
  `split_markdown.sh`, `shuffle_split_files.sh`, and `convert_to_kindle.sh`
- enforce `set -e` and clean up quoting

## Testing
- `shellcheck split_markdown.sh shuffle_split_files.sh convert_to_kindle.sh`

------
https://chatgpt.com/codex/tasks/task_e_6867d658ff58833281c8d0e5fc310b14