### PR TITLE
Add pandoc check

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This repository provides a simple pipeline to convert a folder of documents into
 ## Prerequisites
 
 - Python 3
-- [Pandoc](https://pandoc.org/installing.html) for file conversions
+- [Pandoc](https://pandoc.org/installing.html) for file conversions (required; `convert_to_kindle.sh` will exit if `pandoc` is missing)
 - `kindlegen` (optional, recommended for MOBI output)
 - Unix-like shell environment (Linux, macOS, WSL)
 

--- a/convert_to_kindle.sh
+++ b/convert_to_kindle.sh
@@ -13,6 +13,13 @@ else
   USE_KINDLEGEN=false
 fi
 
+# Ensure pandoc is installed
+if ! command -v pandoc >/dev/null 2>&1; then
+  echo "pandoc is required but was not found."
+  echo "Install it from https://pandoc.org/installing.html and ensure it is in your PATH."
+  exit 1
+fi
+
 for mdfile in "$SPLIT_DIR"/*.md; do
   base_name=$(basename "$mdfile" .md)
   if [ "$USE_KINDLEGEN" = true ]; then


### PR DESCRIPTION
## Summary
- ensure `pandoc` exists before converting to Kindle format
- document `pandoc` requirement in README

## Testing
- `bash -n convert_to_kindle.sh`

------
https://chatgpt.com/codex/tasks/task_e_6867d887ab2c83329f7a5434c8c28ea7