### PR TITLE
Add configure.sh for venv setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ This repository provides a modular pipeline for consolidating a knowledge base i
 
 - Python 3
 - [pandoc](https://pandoc.org/installing.html)
-- `pip install -r requirements.txt` (installs `PyPDF2`, `fpdf` and `pytest`)
+
+Run `./configure.sh` once to create a virtual environment and install the
+packages from `requirements.txt`.
+
+```
+./configure.sh
+source .venv/bin/activate
+```
 
 Ensure `pandoc` is accessible in your `PATH`. Optionally set the environment variable `KB_DIR` to point to your knowledge base. The default is `/home/cinder/Documents/K_Knowledge_Base`.
 

--- a/configure.sh
+++ b/configure.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+VENV_DIR="${1:-.venv}"
+PYTHON_BIN="${PYTHON:-python3}"
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "Python interpreter not found." >&2
+  exit 1
+fi
+
+if [ ! -d "$VENV_DIR" ]; then
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+source "$VENV_DIR/bin/activate"
+
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo "Virtual environment setup complete. Activate with 'source $VENV_DIR/bin/activate'."

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -3,6 +3,7 @@ import pytest
 
 # List of script paths relative to repository root
 SCRIPT_FILES = [
+    'configure.sh',
     'convert_to_kindle.sh',
     'ingest_and_convert.sh',
     'merge.sh',


### PR DESCRIPTION
## Summary
- create `configure.sh` to build a Python venv and install requirements
- document setup via the new script in the README
- verify `configure.sh` is executable via tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd3629c5483328b8ce931f7eb51af