### PR TITLE
Handle pypdf and PyPDF2 imports gracefully

### DIFF
--- a/orchestrate_all.py
+++ b/orchestrate_all.py
@@ -6,7 +6,10 @@ from pathlib import Path
 from datetime import datetime
 from typing import Dict
 
-from PyPDF2 import PdfMerger, PdfReader
+try:
+    from pypdf import PdfMerger, PdfReader
+except ModuleNotFoundError:  # fall back for environments with PyPDF2 installed
+    from PyPDF2 import PdfMerger, PdfReader
 from fpdf import FPDF
 
 KB_DIR = Path(os.environ.get("KB_DIR", "/home/cinder/Documents/K_Knowledge_Base"))


### PR DESCRIPTION
## Summary
- allow orchestrate_all.py to import PdfMerger/PdfReader from either `pypdf` or `PyPDF2`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bd4b2cd5483329b5ac7fee8d77b41