### PR TITLE
Add comment and runtime test for ingest script

### DIFF
--- a/orchestrate_all.py
+++ b/orchestrate_all.py
@@ -58,6 +58,7 @@ def compute_hash(path: Path) -> str:
             h.update(chunk)
     return h.hexdigest()
 
+# This helper mirrors the convert_file function in ingest_and_convert.py
 
 def convert_file(src: Path, dest: Path) -> bool:
     if src.suffix.lower() == ".pdf":

--- a/tests/test_ingest_runtime.py
+++ b/tests/test_ingest_runtime.py
@@ -1,0 +1,12 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_ingest_and_convert_executes(tmp_path):
+    script = Path(__file__).resolve().parents[1] / "ingest_and_convert.py"
+    env = os.environ.copy()
+    env["KB_DIR"] = str(tmp_path)
+    subprocess.run([sys.executable, str(script)], cwd=tmp_path, env=env, check=True)
+    assert (tmp_path / "ledger.json").exists()


### PR DESCRIPTION
## Summary
- reference the ingest helper `convert_file` in `orchestrate_all.py`
- ensure `ingest_and_convert.py` runs successfully via new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd70dea048332a10857c8ceb93a24