### PR TITLE
Use Unicode font for Markdown conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository provides a modular pipeline for consolidating a knowledge base i
 ## Features
 
 - Recursively scan subfolders under the knowledge base directory.
-- Convert Markdown (`.md`/`.mdx`) directly to PDF using FPDF.
+- Convert Markdown (`.md`/`.mdx`) directly to PDF using FPDF with a Unicode font.
 - Convert text (`.txt`) and DOCX files to PDF via `pandoc`.
 - Merge all PDFs in a subfolder into a single file in `Merged/`.
 - Split merged PDFs into ~20,000 word chunks saved in `Chunks/`.
@@ -38,7 +38,7 @@ packages from `requirements.txt`.
 source .venv/bin/activate
 ```
 
-Ensure `pandoc` is accessible in your `PATH` for converting DOCX and text files. Markdown files are handled directly via FPDF, so no LaTeX engine is required. Optionally set the environment variable `KB_DIR` to point to your knowledge base. The default is `/home/cinder/Documents/K_Knowledge_Base`.
+Ensure `pandoc` is accessible in your `PATH` for converting DOCX and text files. Markdown files are handled directly via FPDF, which now embeds the DejaVuSans TrueType font so that Unicode characters render correctly (no LaTeX engine required). Optionally set the environment variable `KB_DIR` to point to your knowledge base. The default is `/home/cinder/Documents/K_Knowledge_Base`.
 
 ## Usage
 

--- a/orchestrate_all.py
+++ b/orchestrate_all.py
@@ -22,7 +22,13 @@ def markdown_to_pdf(src: Path, dest: Path) -> None:
     pdf = FPDF()
     pdf.add_page()
     pdf.set_auto_page_break(True, margin=15)
-    pdf.set_font("Arial", size=12)
+    pdf.add_font(
+        "DejaVu",
+        "",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        uni=True,
+    )
+    pdf.set_font("DejaVu", size=12)
     for line in text.splitlines():
         pdf.multi_cell(0, 10, line)
     pdf.output(str(dest))


### PR DESCRIPTION
## Summary
- handle UTF-8 characters when rendering Markdown to PDF
- document the Unicode font requirement in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bde0af74c8332b68aeac7c6c23cea